### PR TITLE
Remove v-connection_string_custom field

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,3 +19,9 @@ In `connectionProperties.js`, please update `MOTHERDUCK_CONNECTOR_VERSION` to th
 
 [See the detailed steps](./docs/unsigned_connector.md).
 
+## Running connector under development
+
+On Windows:
+```
+tableau.exe -DConnectPluginsPath=[CONNECTOR_LOCATION]
+```

--- a/README.md
+++ b/README.md
@@ -61,11 +61,6 @@ To work with a MotherDuck database in Tableau, you have to provide the database 
 In `MotherDuck Database` field, provide the name of your database. You don't have to prefix it with `md:`:
 <img alt="Connection Dialogue" src="images/tableau-connect-motherduck.png" width="50%">
 
-## Other 
-
-This option allows you to provide the full JDBC connection string manually by typing a file path, `:memory:` or `md:database_name`.
-In most cases, one of the more specialized options (Local file, In-Memory Database, MotherDuck) will be simpler to use.
-
 ## Using
 
 Once connected, you can use the Tableau connection window to choose schemas, join tables,

--- a/tableau_connectors/duckdb_jdbc/connectionBuilder.js
+++ b/tableau_connectors/duckdb_jdbc/connectionBuilder.js
@@ -13,8 +13,6 @@
 
     } else if (attr[connectionHelper.attributeServer] === "memory") {
         connectionString = ":memory:";
-    } else if (attr[connectionHelper.attributeServer] === "custom") {
-        connectionString = String(attr['v-connection_string_custom']);
     }
 
     if (connectionString.startsWith("md:")) {

--- a/tableau_connectors/duckdb_jdbc/connectionFields.xml
+++ b/tableau_connectors/duckdb_jdbc/connectionFields.xml
@@ -6,7 +6,6 @@
       <option value="local" label="Local File"/>
       <option value="memory" label="In-memory database"/>
       <option value="motherduck" label="MotherDuck"/>
-      <option value="custom" label="Custom connection string"/>
     </selection-group>
   </field>
 
@@ -14,7 +13,6 @@
     <selection-group>
       <conditions>
         <condition field="server" value="motherduck"/>
-        <condition field="server" value="custom"/>
       </conditions>
       <option value="auth-none" label="No Authentication"/>
       <option value="auth-pass" label="Token"/>
@@ -41,11 +39,6 @@
   <field name="v-connection_string_md" label="MotherDuck Database" category="general" value-type="string" editable="true" default-value="" >
     <conditions>
       <condition field="server" value="motherduck"/>
-    </conditions>
-  </field>
-  <field name="v-connection_string_custom" label="Connection String" category="general" value-type="string" editable="true" default-value=":memory:" >
-    <conditions>
-      <condition field="server" value="custom"/>
     </conditions>
   </field>
 </connection-fields>

--- a/tableau_connectors/duckdb_jdbc/connectionResolver.tdr
+++ b/tableau_connectors/duckdb_jdbc/connectionResolver.tdr
@@ -11,7 +11,6 @@
             <attr>server</attr>
             <attr>password</attr>
             <attr>initialSQL</attr>
-            <attr>v-connection_string_custom</attr>
             <attr>v-connection_string_md</attr>
             <attr>v-connection_string_file</attr>
           </attribute-list>


### PR DESCRIPTION
Removing the custom connection string since free form fields are not allowed for official Tableau connectors.

Fixes Tabloids/MotherDuck-Connector#1