### PR TITLE
docs: Update JDBC driver location 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ The connector works with DuckDB JDBC driver v0.9.2 or higher.
 
 ## Installation
 
-1. Download a [recent version of the DuckDB JDBC driver](https://github.com/duckdb/duckdb/releases) and copy it into the Tableau Drivers directory:
-   * Desktop Windows: `C:\Users\[YourUser]\Documents\My Tableau Repository\Drivers`
-   * Desktop MacOS: `/Users/[YourUser]/Documents/My Tableau Repository/Drivers`
-   * Server Windows: `C:\ProgramData\Tableau\Tableau Server\data\tabsvc\vizqlserver\Drivers`
-   * Server Linux: `[Your Tableau Server Install Directory]/data/tabsvc/vizqlserver/Drivers`
+1. Download a [recent version of the DuckDB JDBC driver](https://repo1.maven.org/maven2/org/duckdb/duckdb_jdbc/) and copy it into the Tableau Drivers directory:
+  * MacOS: `~/Library/Tableau/Drivers/`
+  * Windows: `C:\Program Files\Tableau\Drivers`
+  * Linux: `/opt/tableau/tableau_driver/jdbc`
 
 2. Download the signed tableau connector (aka "Taco file") file from the [latest available release](https://github.com/MotherDuck-Open-Source/duckdb-tableau-connector/releases) and copy it into the Connectors directory:
    * Desktop Windows: `C:\Users\[YourUser]\Documents\My Tableau Repository\Connectors`


### PR DESCRIPTION
1) Drivers are not under `My Tableau Repository`
2) Linked to Maven central rather than Github release.