### PR TITLE
Use fully qualified table names

### DIFF
--- a/tableau_connectors/duckdb_jdbc/connectionProperties.js
+++ b/tableau_connectors/duckdb_jdbc/connectionProperties.js
@@ -1,5 +1,5 @@
 (function propertiesbuilder(attr) {
-    const MOTHERDUCK_CONNECTOR_VERSION = '1.1.0';
+    const MOTHERDUCK_CONNECTOR_VERSION = '1.1.1';
 
     // These are the DBClientConfig properties
     var props = {};

--- a/tableau_connectors/duckdb_jdbc/manifest.xml
+++ b/tableau_connectors/duckdb_jdbc/manifest.xml
@@ -27,6 +27,7 @@
       <customization name="CAP_SUPPORTS_SPLIT_FROM_RIGHT" value="yes"/>
       <customization name="CAP_SUPPORTS_UNION" value="yes"/>
       <customization name="CAP_QUERY_ALLOW_PARTIAL_AGGREGATION" value="no"/>
+      <customization name="CAP_JDBC_INCLUDE_CATALOG_NAME" value="yes"/>
     </customizations>
   </connection-customization>
   <connection-fields file='connectionFields.xml'/>

--- a/tableau_connectors/duckdb_jdbc/manifest.xml
+++ b/tableau_connectors/duckdb_jdbc/manifest.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='utf-8' ?>
 
-<connector-plugin class='duckdb_jdbc' superclass='jdbc' plugin-version='1.1.0' name='DuckDB' version='18.1' min-version-tableau='2020.4'>
+<connector-plugin class='duckdb_jdbc' superclass='jdbc' plugin-version='1.1.1' name='DuckDB' version='18.1' min-version-tableau='2020.4'>
   <vendor-information>
       <company name="MotherDuck"/>
       <support-link url="https://github.com/MotherDuck-Open-Source/duckdb-tableau-connector"/>


### PR DESCRIPTION
fully qualify the Table names with [Database].[Schema].[Table] instead of the default which is [Schema].[Table].
Fixes #9 