### PR TITLE
Upgrade github action versions

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,12 +16,12 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
     - name: Checkout Taco
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         path: taco
 
     - name: Checkout SDK
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         repository: tableau/connector-plugin-sdk
         path: sdk
@@ -44,14 +44,14 @@ jobs:
         popd
 
     - name: Upload Taco
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: duckdb_taco
         path: |
           sdk/connector-packager/packaged-connector/duckdb_jdbc*.taco
 
     - name: Upload Connector
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: duckdb_jdbc
         path: |


### PR DESCRIPTION
Per https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/